### PR TITLE
Avoid the edit of the vhost config in ubuntu

### DIFF
--- a/modules/apache_admin/hooks/OnDaemonRun.hook.php
+++ b/modules/apache_admin/hooks/OnDaemonRun.hook.php
@@ -88,7 +88,8 @@ function WriteVhostConfigFile()
 
     # Listen is mandatory for each port <> 80 (80 is defined in system config)
     foreach ($customPortList as $port) {
-        $line .= "Listen " . $port . fs_filehandler::NewLine();
+    	if ($port <> 443)
+        	$line .= "Listen " . $port . fs_filehandler::NewLine();
     }
 
     $line .= fs_filehandler::NewLine();


### PR DESCRIPTION
Fix the apache restart error for busy 443 port.
A check for ubuntu-only should be added
